### PR TITLE
fix: standardize release config (drop legacy npm publication)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/github",
-      "@semantic-release/npm",
       [
         "@semantic-release/exec",
         {


### PR DESCRIPTION
mod-gsap was the only module still publishing to npm (`@semantic-release/npm`), a legacy pattern no longer used. Removes it so the release config matches the other modules (git + GitHub release only). This also resolves the release failure (`No npm token specified`) without needing an NPM_TOKEN.