### PR TITLE
feat: declare gsap/ScrollTrigger/SplitText as script globals

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,3 +25,15 @@
 [params.modules.gsap]
   integration = "core"
   state = "defer"
+  # GSAP's UMD builds do not self-register on window when bundled by
+  # esbuild; expose them explicitly so Hinode's scripts pipeline (and
+  # consumer animation code using bare globals) can resolve them.
+  [[params.modules.gsap.globals]]
+    path = "js/modules/gsap/_core/gsap.js"
+    name = "gsap"
+  [[params.modules.gsap.globals]]
+    path = "js/modules/gsap/_core/ScrollTrigger.js"
+    name = "ScrollTrigger"
+  [[params.modules.gsap.globals]]
+    path = "js/modules/gsap/_core/SplitText.js"
+    name = "SplitText"


### PR DESCRIPTION
## Summary

GSAP's UMD builds do not self-register on `window` when bundled by esbuild under Hinode v3.7's ES-module scripts pipeline, so consumer code using the bare `gsap` / `ScrollTrigger` / `SplitText` globals throws `gsap is not defined`.

This declares those three globals via Hinode's module-globals mechanism, using the **array-of-tables** form `[[params.modules.gsap.globals]]` with `path` + `name`. The array form is required here: Hugo lowercases TOML config keys, so a path-keyed map would break the **capitalized** filenames `ScrollTrigger.js` / `SplitText.js`. CSSPlugin is not declared — it ships inside the gsap core bundle and is auto-registered.

## Requires

Hinode with the array-of-tables globals reader (v3.10.0+ — released from hinode#2064; that reader also still accepts the legacy map form).

## Verification

Proven end-to-end on a real consumer (infusal.io): production build injects `window.gsap` (3.15.0), `window.ScrollTrigger`, `window.SplitText` — all case-correct — 6 ScrollTriggers created, every animation renders, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)